### PR TITLE
replace null value with empty string for language field

### DIFF
--- a/definitions/digital_analytics_domain/base/ga4_events.sqlx
+++ b/definitions/digital_analytics_domain/base/ga4_events.sqlx
@@ -69,7 +69,7 @@ SELECT
   stream_id,
   user_pseudo_id,
   user_id,
-  language,
+  ${notNullString('language')},
   COALESCE(left(language, 2), "") as normalized_language,
   COALESCE(device_advertising_id, "") device_advertising_id,
   ga_session_id,


### PR DESCRIPTION

device language field is use in join processes, when it get null value the join is not working as expected.
Also the device_type table, get lot duplicate entry due to the null values.
Replace null with empty string