### PR TITLE
Filter Google Analytics data similar to Ads

### DIFF
--- a/definitions/digital_analytics_domain/base/event.sqlx
+++ b/definitions/digital_analytics_domain/base/event.sqlx
@@ -43,6 +43,21 @@ pre_operations {
   'SELECT "ignore_it"')
     }
 }
+post_operations {
+  -- Remove data not needed according to settings.
+  ${when(incremental(), `DECLARE latest_datetime DATETIME;
+    SET latest_date = (
+      SELECT MAX(DATETIME_TRUNC(event_timestamp, DAY))
+      FROM ${self()}
+    )`,
+  `DELETE FROM ${self()}
+    WHERE DATETIME_TRUNC(event_timestamp, DAY)
+      < DATETIME_SUB(
+        latest_datetime,
+        INTERVAL ${dataform.projectConfig.vars.ga4_metrics_lookback_days} DAY
+      )`)
+    }
+}
   SELECT
     GENERATE_UUID() as event_id,
     CASE 

--- a/definitions/digital_analytics_domain/base/ga4_events.sqlx
+++ b/definitions/digital_analytics_domain/base/ga4_events.sqlx
@@ -31,6 +31,8 @@ js {
   function notNullString(column, columnName) {
     return 'COALESCE(' + column + ', "") as ' + columnName;
   }
+  // Exclude extra day exports 
+  const excludeExtraDays = 'NOT STARTS_WITH(_TABLE_SUFFIX, "intraday") OR NOT STARTS_WITH(_TABLE_SUFFIX, "fresh")';
 }
 
 config { 
@@ -40,7 +42,13 @@ config {
   description: "View into GA4 exported tables. Not be used outside of the Dataform transformation jobs.",
   tags: ['ga4']
 }
-
+DECLARE latest_date DATE;
+SET latest_date = (
+  SELECT MAX(SAFE.PARSE_DATE(_TABLE_SUFFIX))
+  FROM ${ref('events' + dataform.projectConfig.vars.ga4_export_table_suffix)}
+  -- Exclude extra day exports 
+  WHERE ${excludeExtraDays}
+);    
 SELECT
   --traffic_source dimension
   ${notNullString('traffic_source_medium', 'traffic_source_medium')},
@@ -182,7 +190,10 @@ SELECT
     is_active_user,
     _TABLE_SUFFIX as table_suffix
 FROM ${ref('events' + dataform.projectConfig.vars.ga4_export_table_suffix)}
-  -- Exclude extra day exports 
-  WHERE NOT STARTS_WITH(_TABLE_SUFFIX, "intraday")
-  OR NOT STARTS_WITH(_TABLE_SUFFIX, "fresh")
+WHERE ${excludeExtraDays}
+  AND _TABLE_SUFFIX > 
+    FORMAT_DATE("%Y%m%d", DATE_SUB(
+      latest_date,
+      INTERVAL ${dataform.projectConfig.vars.ga4_metrics_lookback_days} DAY
+    ))
 )


### PR DESCRIPTION
Let's add an option to not include all historic Google Analytics data. This will reduce processing cost for both AutoML and dataform.